### PR TITLE
Replace range/v3/all.hpp include with individual include files

### DIFF
--- a/src/interpolation.hpp
+++ b/src/interpolation.hpp
@@ -20,7 +20,7 @@
 #include "range/v3/view/drop_exactly.hpp"
 #include "range/v3/view/transform.hpp"
 #include "range/v3/view/join.hpp"
-#include "header-utilities.hpp"
+#include "header-utilities/void_t.hpp"
 
 namespace njoy {
 

--- a/src/interpolation.hpp
+++ b/src/interpolation.hpp
@@ -9,7 +9,17 @@
 
 #include "Log.hpp"
 #include "boost/hana.hpp"
-#include "range/v3/all.hpp"
+//#include "range/v3/all.hpp"
+#include "range/v3/iterator_range.hpp"
+#include "range/v3/algorithm/adjacent_find.hpp"
+#include "range/v3/algorithm/find_if.hpp"
+#include "range/v3/algorithm/is_sorted.hpp"
+#include "range/v3/algorithm/lower_bound.hpp"
+#include "range/v3/utility/iterator.hpp"
+#include "range/v3/view/concat.hpp"
+#include "range/v3/view/drop_exactly.hpp"
+#include "range/v3/view/transform.hpp"
+#include "range/v3/view/join.hpp"
 #include "header-utilities.hpp"
 
 namespace njoy {

--- a/src/interpolation/Interpolant/LinearLogarithmic/test/interpolate.test.cpp
+++ b/src/interpolation/Interpolant/LinearLogarithmic/test/interpolate.test.cpp
@@ -3,6 +3,8 @@
 
 #include "dimwits.hpp"
 
+#include "range/v3/view/take.hpp"
+
 using namespace njoy::interpolation;
 using namespace dimwits;
 
@@ -20,7 +22,7 @@ SCENARIO("The LinearLogarithmic interpolant computes the correct value",
     auto error = std::abs( (trial - reference)
 			   / ( ( reference != 0 ) ? reference : 1.0 ) );
     return error > 1E-15; };
-  
+
   auto iterator = xValues.begin();
   auto last = std::prev( xValues.end() );
   do {
@@ -28,7 +30,7 @@ SCENARIO("The LinearLogarithmic interpolant computes the correct value",
     double y1Left = f1( xLeft ), y1Right = f1( xRight );
     double y2Left = f2( xLeft ), y2Right = f2( xRight );
     double xBar = avg( xLeft, xRight );
-    
+
     REQUIRE( not excessiveError( y1Left,
                                  LinearLogarithmic::apply
                                  ( xLeft, xLeft, xRight, y1Left, y1Right ) ) );
@@ -71,7 +73,7 @@ SCENARIO("The LinearLogarithmic interpolant computes is compatible with units",
     auto y1Left = f1( xLeft ), y1Right = f1( xRight );
     auto y2Left = f2( xLeft ), y2Right = f2( xRight );
     auto xBar = avg( xLeft, xRight );
-    
+
     REQUIRE( not excessiveError( y1Left,
                                  LinearLogarithmic::apply
                                  ( xLeft, xLeft, xRight, y1Left, y1Right ) ) );

--- a/src/interpolation/Interpolant/LinearLogarithmic/test/invert.test.cpp
+++ b/src/interpolation/Interpolant/LinearLogarithmic/test/invert.test.cpp
@@ -3,6 +3,8 @@
 
 #include "dimwits.hpp"
 
+#include "range/v3/view/take.hpp"
+
 using namespace njoy::interpolation;
 using namespace dimwits;
 
@@ -18,7 +20,7 @@ SCENARIO("The LinearLogarithmic interpolant computes the correct inversion",
     auto error = std::abs( (trial - reference)
 			   / ( ( reference != 0 ) ? reference : 1.0 ) );
     return error > 1E-15; };
-  
+
   auto iterator = xValues.begin();
   auto last = std::prev( xValues.end() );
   do {
@@ -65,7 +67,7 @@ SCENARIO("LinearLogarithmic computes the correct inversion with units",
   auto units = xValues |
     ranges::view::take( xValues.size() - 1 ) |
     ranges::view::transform( []( auto arg ){ return arg * electronVolts; } );
-  
+
   auto iterator = units.begin();
   auto last = units.end();
   do {

--- a/src/interpolation/Interpolant/LogarithmicLinear/test/apply.test.cpp
+++ b/src/interpolation/Interpolant/LogarithmicLinear/test/apply.test.cpp
@@ -3,6 +3,8 @@
 
 #include "dimwits.hpp"
 
+#include "range/v3/view/take.hpp"
+
 using namespace njoy::interpolation;
 
 SCENARIO("The LogarithmicLinear interpolant computes the correct value",
@@ -17,7 +19,7 @@ SCENARIO("The LogarithmicLinear interpolant computes the correct value",
     auto error = std::abs( (trial - reference)
                            / ( ( reference != 0 ) ? reference : 1.0 ) );
     return error > 1E-15; };
-  
+
   auto iterator = xValues.begin();
   auto last = std::prev( xValues.end() );
   do {
@@ -25,7 +27,7 @@ SCENARIO("The LogarithmicLinear interpolant computes the correct value",
     double y1Left = f1( xLeft ), y1Right = f1( xRight );
     double y2Left = f2( xLeft ), y2Right = f2( xRight );
     double xBar = avg( xLeft, xRight );
-    
+
     REQUIRE( not excessiveError( y1Left,
                                  LogarithmicLinear::apply
                                  ( xLeft, xLeft, xRight, y1Left, y1Right ) ) );
@@ -69,7 +71,7 @@ SCENARIO("The LogarithmicLinear interpolant computes is compatible with units",
     auto y1Left = f1( xLeft ), y1Right = f1( xRight );
     auto y2Left = f2( xLeft ), y2Right = f2( xRight );
     auto xBar = avg( xLeft, xRight );
-    
+
     REQUIRE( not excessiveError( y1Left,
                                  LogarithmicLinear::apply
                                  ( xLeft, xLeft, xRight, y1Left, y1Right ) ) );

--- a/src/interpolation/Interpolant/LogarithmicLinear/test/invert.test.cpp
+++ b/src/interpolation/Interpolant/LogarithmicLinear/test/invert.test.cpp
@@ -3,6 +3,8 @@
 
 #include "dimwits.hpp"
 
+#include "range/v3/view/take_exactly.hpp"
+
 using namespace njoy::interpolation;
 using namespace dimwits;
 
@@ -18,7 +20,7 @@ SCENARIO("The LinearLogarithmic interpolant computes the correct inversion",
     auto error = std::abs( (trial - reference)
 			   / ( ( reference != 0 ) ? reference : 1.0 ) );
     return error > 5E-14; };
-  
+
   auto iterator = xValues.begin();
   auto last = std::prev( xValues.end() );
   do {
@@ -64,7 +66,7 @@ SCENARIO("LogarithmicLinear computes the correct inversion with units",
   auto units = xValues |
     ranges::view::take_exactly( xValues.size() - 1 ) |
     ranges::view::transform( []( auto arg ){ return arg * electronVolts; } );
-  
+
   auto iterator = units.begin();
   auto last = units.end();
   do {

--- a/src/interpolation/Interpolant/LogarithmicLogarithmic/test/invert.test.cpp
+++ b/src/interpolation/Interpolant/LogarithmicLogarithmic/test/invert.test.cpp
@@ -3,6 +3,8 @@
 
 #include "dimwits.hpp"
 
+#include "range/v3/view/take_exactly.hpp"
+
 using namespace njoy::interpolation;
 using namespace dimwits;
 
@@ -22,7 +24,7 @@ SCENARIO("The LinearLogarithmic interpolant computes the correct inversion",
     auto error = std::abs( (trial - reference)
 			   / ( ( reference != 0 ) ? reference : 1.0 ) );
     return error > 5E-14; };
-  
+
   auto iterator = xValues.begin();
   auto last = std::prev( xValues.end() );
   do {
@@ -69,7 +71,7 @@ SCENARIO("LogarithmicLogarithmic computes the correct inversion with units",
   auto units = xValues |
     ranges::view::take_exactly( xValues.size() - 1 ) |
     ranges::view::transform( []( auto arg ){ return arg * electronVolts; } );
-  
+
   auto iterator = units.begin();
   auto last = units.end();
   do {

--- a/src/interpolation/table/Table/test/Table.test.cpp
+++ b/src/interpolation/table/Table/test/Table.test.cpp
@@ -4,6 +4,8 @@
 #include "dimwits.hpp"
 #include "interpolation.hpp"
 
+#include "range/v3/algorithm/equal.hpp"
+
 using namespace njoy::interpolation;
 using namespace dimwits;
 
@@ -38,7 +40,7 @@ SCENARIO("An interpolation table can be constructed"){
 
       Table< table::Type< LinearLinear,
 			  table::search::Binary,
-			  table::discontinuity::TakeLeft, 
+			  table::discontinuity::TakeLeft,
 			  std::vector< double >,
 			  std::vector< double > >,
 	     table::domain::min::IsCompiletimeConstant<Zero>,
@@ -79,7 +81,7 @@ SCENARIO("An interpolation table can be constructed"){
 	REQUIRE(  myTable.tableMin() ==  xGrid.front() );
 	REQUIRE(  myTable.tableMax() ==  xGrid.back() );
       }
-      
+
       THEN("the domain left limit is negative infinity"){
 	REQUIRE( myTable.domainMin() == 0.0 );
       }

--- a/src/interpolation/table/Table/test/Table.test.cpp
+++ b/src/interpolation/table/Table/test/Table.test.cpp
@@ -6,6 +6,8 @@
 
 #include "range/v3/algorithm/equal.hpp"
 
+#include "header-utilities/copy.hpp"
+
 using namespace njoy::interpolation;
 using namespace dimwits;
 

--- a/src/interpolation/table/Type/test/Type.test.cpp
+++ b/src/interpolation/table/Type/test/Type.test.cpp
@@ -4,6 +4,8 @@
 #include "dimwits.hpp"
 #include "interpolation.hpp"
 
+#include "range/v3/algorithm/equal.hpp"
+
 using namespace njoy::interpolation;
 using namespace dimwits;
 
@@ -37,7 +39,7 @@ SCENARIO("An interpolation table can be constructed"){
       THEN("the table can be evaluated"){
 	REQUIRE( 3.0 == myTable( 1.0 ) );
 	REQUIRE( 7.0 == myTable( 3.0 ) );
-	
+
 	REQUIRE( 6.5 == myTable( 2.5 ) );
 	REQUIRE( 6.5 == myTable( 2.5, myTable.search() ) );
       }
@@ -58,7 +60,7 @@ SCENARIO("An interpolation table can be constructed"){
 	REQUIRE(  myTable.tableMin() ==  xGrid.front() );
 	REQUIRE(  myTable.tableMax() ==  xGrid.back() );
       }
-      
+
       THEN("the domain left limit is negative infinity"){
 	REQUIRE( myTable.domainMin() == -infinity<double>() );
       }
@@ -71,7 +73,7 @@ SCENARIO("An interpolation table can be constructed"){
     THEN("interpolation tables can be constructed which refs each component"){
       auto x = xGrid | ranges::view::all;
       auto y = yGrid | ranges::view::all;
-      
+
       Table< table::Type< LinearLinear,
 			  table::search::Binary,
 			  table::discontinuity::TakeLeft,
@@ -89,7 +91,7 @@ SCENARIO("An interpolation table can be constructed"){
 
       THEN("the table can provide y-values"){
 	REQUIRE( ranges::equal( myTable.y(), yGrid ) );
-      }      
+      }
     }
 
     THEN("interpolation tables can hash query values"){
@@ -102,7 +104,7 @@ SCENARIO("An interpolation table can be constructed"){
       THEN("the table can be evaluated"){
 	REQUIRE( 3.0 == myTable( 1.0 ) );
 	REQUIRE( 7.0 == myTable( 3.0 ) );
-	
+
 	REQUIRE( 6.5 == myTable( 2.5 ) );
 	REQUIRE( 6.5 == myTable( 2.5, myTable.search() ) );
       }
@@ -120,13 +122,13 @@ SCENARIO("An interpolation table can be constructed"){
 	myTable( njoy::utility::copy(xGrid), njoy::utility::copy(yGrid) );
 
       auto search = myTable.cachedSearch();
-      
+
       THEN("the table can be evaluated"){
 	REQUIRE( 3.0 == myTable( 1.0, search ) );
 	REQUIRE( 3.0 == myTable( 1.0, search ) );
 	REQUIRE( 7.0 == myTable( 3.0, search ) );
 	REQUIRE( 7.0 == myTable( 3.0, search ) );
-	
+
 	REQUIRE( 6.5 == myTable( 2.5, search ) );
 	REQUIRE( 6.5 == myTable( 2.5, search ) );
       }
@@ -143,7 +145,7 @@ SCENARIO("An interpolation table can be constructed"){
 
       Table< table::Type< LinearLinear,
 			  table::search::Binary,
-			  table::discontinuity::TakeLeft, 
+			  table::discontinuity::TakeLeft,
 			  decltype(x), decltype(y) > >
       	myTable( njoy::utility::copy(x), njoy::utility::copy(y) );
 
@@ -164,7 +166,7 @@ SCENARIO("An interpolation table can be constructed"){
 	REQUIRE( myTable.tableMin() == x.front() );
 	REQUIRE( myTable.tableMax() == x.back() );
       }
-      
+
       THEN("the domain left limit is negative infinity"){
 	REQUIRE( myTable.domainMin() == -infinity< Quantity<Meter> >() );
       }
@@ -188,7 +190,7 @@ SCENARIO("Exceptional behavior"){
   GIVEN("zero length x-grid"){
     std::vector<double> xgrid{};
     std::vector<double> ygrid{};
-    
+
     THEN("construction will throw"){
       REQUIRE_THROWS( construct( njoy::utility::copy(xgrid),
 				 njoy::utility::copy(ygrid) ) );
@@ -198,7 +200,7 @@ SCENARIO("Exceptional behavior"){
   GIVEN("mismatched grid lengths"){
     std::vector<double> xgrid{ 1.0, 2.0, 3.0 };
     std::vector<double> ygrid{ 1.0, 2.0, 3.0, 4.0 };
-    
+
     THEN("construction will throw"){
       REQUIRE_THROWS( construct( njoy::utility::copy(xgrid),
 				 njoy::utility::copy(ygrid) ) );
@@ -208,7 +210,7 @@ SCENARIO("Exceptional behavior"){
   GIVEN("unsorted x-grid"){
     std::vector<double> xgrid{ 1.0, 3.0, 2.0 };
     std::vector<double> ygrid{ 1.0, 2.0, 3.0 };
-    
+
     THEN("construction will throw"){
       REQUIRE_THROWS( construct( njoy::utility::copy(xgrid),
 				 njoy::utility::copy(ygrid) ) );
@@ -219,7 +221,7 @@ SCENARIO("Exceptional behavior"){
 SCENARIO("copy/move ctor regression test"){
   std::vector<double> xgrid{ 1.0, 2.0, 3.0 };
   std::vector<double> ygrid{ 1.0, 2.0, 3.0 };
-  
+
   auto reference =
     table::make< LinearLinear,
                  table::search::Hashed< Binary > >( std::move(xgrid),

--- a/src/interpolation/table/Type/test/Type.test.cpp
+++ b/src/interpolation/table/Type/test/Type.test.cpp
@@ -6,6 +6,8 @@
 
 #include "range/v3/algorithm/equal.hpp"
 
+#include "header-utilities/copy.hpp"
+
 using namespace njoy::interpolation;
 using namespace dimwits;
 

--- a/src/interpolation/table/Variant/test/Variant.test.cpp
+++ b/src/interpolation/table/Variant/test/Variant.test.cpp
@@ -5,6 +5,8 @@
 
 #include "range/v3/algorithm/equal.hpp"
 
+#include "header-utilities/copy.hpp"
+
 using namespace njoy::interpolation;
 
 SCENARIO("An variant interpolation table can be constructed"){

--- a/src/interpolation/table/Variant/test/Variant.test.cpp
+++ b/src/interpolation/table/Variant/test/Variant.test.cpp
@@ -3,6 +3,8 @@
 #include "catch.hpp"
 #include "interpolation.hpp"
 
+#include "range/v3/algorithm/equal.hpp"
+
 using namespace njoy::interpolation;
 
 SCENARIO("An variant interpolation table can be constructed"){
@@ -14,20 +16,20 @@ SCENARIO("An variant interpolation table can be constructed"){
       using Law2 =
 	Table< table::Type< LinearLinear,
 			    table::search::Binary,
-			    table::discontinuity::TakeLeft, 
+			    table::discontinuity::TakeLeft,
 			    std::vector< double >, std::vector< double > > >;
-      
+
       using Law5 =
 	Table< table::Type< LogarithmicLogarithmic,
 			    table::search::Binary,
-			    table::discontinuity::TakeLeft, 
+			    table::discontinuity::TakeLeft,
 			    std::vector< double >, std::vector< double > > >;
 
       Table< table::Variant< Law2, Law5 > >
 	myTable( Law2( njoy::utility::copy(xGrid), njoy::utility::copy(yGrid) ) );
 
       bool correct;
-      
+
       correct = ranges::equal( myTable.x(), xGrid );
       REQUIRE( correct );
 
@@ -50,17 +52,17 @@ SCENARIO("An variant interpolation table can be constructed"){
       Table< table::Variant< Law2, Law5 > > t1 = law2;
       Table< table::Variant< Law2, Law5 > > t2 = law5;
     }
-    
+
     GIVEN("Variants with distinct underlying data types"){
       using Law2 = Table< table::Type< LinearLinear,
     				       table::search::Binary,
-    				       table::discontinuity::TakeLeft, 
+    				       table::discontinuity::TakeLeft,
     				       std::vector< double >,
     				       std::vector< double > > >;
-      
+
       using Law5 = Table< table::Type< LogarithmicLogarithmic,
     				       table::search::Binary,
-    				       table::discontinuity::TakeLeft, 
+    				       table::discontinuity::TakeLeft,
     				       std::array< double, 3 >,
     				       std::array< double, 3 > > >;
 
@@ -69,7 +71,7 @@ SCENARIO("An variant interpolation table can be constructed"){
     		       njoy::utility::copy(yGrid) ) );
 
       bool correct;
-      
+
       correct = ranges::equal( myTable.x(), xGrid );
       REQUIRE( correct );
 
@@ -78,7 +80,7 @@ SCENARIO("An variant interpolation table can be constructed"){
 
       REQUIRE( 6.0 == myTable( 2.5 ) );
       REQUIRE( 6.0 == myTable( 2.5, myTable.search() ) );
-      
+
       REQUIRE( -infinity<double>() == myTable.domainMin() );
       REQUIRE( infinity<double>() == myTable.domainMax() );
 

--- a/src/interpolation/table/Vector/test/Vector.test.cpp
+++ b/src/interpolation/table/Vector/test/Vector.test.cpp
@@ -6,6 +6,8 @@
 #include "range/v3/algorithm/equal.hpp"
 #include "range/v3/view/take_exactly.hpp"
 
+#include "header-utilities/copy.hpp"
+
 using namespace njoy::interpolation;
 
 SCENARIO("An variant interpolation table can be constructed"){

--- a/src/interpolation/table/Vector/test/Vector.test.cpp
+++ b/src/interpolation/table/Vector/test/Vector.test.cpp
@@ -3,6 +3,9 @@
 #include "catch.hpp"
 #include "interpolation.hpp"
 
+#include "range/v3/algorithm/equal.hpp"
+#include "range/v3/view/take_exactly.hpp"
+
 using namespace njoy::interpolation;
 
 SCENARIO("An variant interpolation table can be constructed"){
@@ -13,11 +16,11 @@ SCENARIO("An variant interpolation table can be constructed"){
     GIVEN("a Vector can be constructed"){
       const auto leftSize = 3;
       const auto rightSize = 6;
-      
+
       auto xLeft = xGrid
 	| ranges::view::drop_exactly( 0 )
 	| ranges::view::take_exactly( leftSize );
-      
+
       auto yLeft = yGrid
 	| ranges::view::drop_exactly( 0 )
 	| ranges::view::take_exactly( leftSize );
@@ -32,7 +35,7 @@ SCENARIO("An variant interpolation table can be constructed"){
 
       using Component = Table< table::Type< LinearLinear,
 					    table::search::Binary,
-					    table::discontinuity::TakeLeft, 
+					    table::discontinuity::TakeLeft,
 					    decltype(xLeft), decltype(yLeft) > >;
 
       const std::vector<Component> core{ Component( njoy::utility::copy(xLeft),
@@ -48,7 +51,7 @@ SCENARIO("An variant interpolation table can be constructed"){
       REQUIRE( vc.domainMax() == infinity<double>() );
       REQUIRE( not vc.specifiesLeftInterval() );
       REQUIRE( not vc.specifiesRightInterval() );
-      REQUIRE( not vc.specifiesDomainMin() ); 
+      REQUIRE( not vc.specifiesDomainMin() );
       REQUIRE( not vc.specifiesDomainMax() );
 
       bool correct;
@@ -56,7 +59,7 @@ SCENARIO("An variant interpolation table can be constructed"){
       REQUIRE(correct);
       correct = ranges::equal( vc.y(), yGrid );
       REQUIRE(correct);
-      
+
       REQUIRE( core[0](2.5) == vc(2.5) );
       REQUIRE( core[1](6.5) == vc(6.5) );
     }
@@ -69,7 +72,7 @@ SCENARIO("An variant interpolation table can be constructed"){
         auto xLeft = xGrid
 	  | ranges::view::drop_exactly( 0 )
 	  | ranges::view::take_exactly( leftSize );
-	
+
 	auto yLeft = yGrid
 	  | ranges::view::drop_exactly( 0 )
 	  | ranges::view::take_exactly( leftSize );
@@ -84,7 +87,7 @@ SCENARIO("An variant interpolation table can be constructed"){
 
 	using Component = Table< table::Type< LinearLinear,
 					      table::search::Binary,
-					      table::discontinuity::TakeLeft, 
+					      table::discontinuity::TakeLeft,
 					      decltype(xLeft), decltype(yLeft) > >;
 
 	const std::vector<Component> core{ Component( njoy::utility::copy(xLeft),
@@ -100,7 +103,7 @@ SCENARIO("An variant interpolation table can be constructed"){
 	auto xLeft = xGrid
 	  | ranges::view::drop_exactly( 0 )
 	  | ranges::view::take_exactly( leftSize + 1);
-	
+
 	auto yLeft = yGrid
 	  | ranges::view::drop_exactly( 0 )
 	  | ranges::view::take_exactly( leftSize + 1 );
@@ -115,7 +118,7 @@ SCENARIO("An variant interpolation table can be constructed"){
 
 	using Component = Table< table::Type< LinearLinear,
 					      table::search::Binary,
-					      table::discontinuity::TakeLeft, 
+					      table::discontinuity::TakeLeft,
 					      decltype(xLeft), decltype(yLeft) > >;
 
 	const std::vector<Component> core{ Component( njoy::utility::copy(xLeft),

--- a/src/interpolation/table/domain/max/IsCompiletimeConstant/test/IsCompiletimeConstant.test.cpp
+++ b/src/interpolation/table/domain/max/IsCompiletimeConstant/test/IsCompiletimeConstant.test.cpp
@@ -4,6 +4,8 @@
 #include "dimwits.hpp"
 #include "interpolation.hpp"
 
+#include "header-utilities/copy.hpp"
+
 using namespace njoy::interpolation;
 using namespace dimwits;
 
@@ -11,13 +13,13 @@ struct Four { static constexpr double value = 4.0; };
 
 SCENARIO("An interpolation table can be constructed with a domain maximum"){
   GIVEN("an x- and y-grid"){
-    
+
     std::vector< double > xGrid{1.0, 2.0, 3.0};
     std::vector< double > yGrid{3.0, 5.0, 7.0};
 
     Table< table::Type< LinearLinear,
 			table::search::Binary,
-			table::discontinuity::TakeLeft, 
+			table::discontinuity::TakeLeft,
 			std::vector< double >,
 			std::vector< double > >,
 	   table::domain::max::IsCompiletimeConstant<Four> >
@@ -26,7 +28,7 @@ SCENARIO("An interpolation table can be constructed with a domain maximum"){
     THEN("the table can be evaluated in the center interval"){
       REQUIRE( 4.0 == myTable.domainMax() );
     }
-    
+
     THEN("the table can be evaluated in the center interval"){
       REQUIRE( 6.0 == myTable( 2.5 ) );
     }

--- a/src/interpolation/table/domain/max/IsRuntimeConstant/test/IsRuntimeConstant.test.cpp
+++ b/src/interpolation/table/domain/max/IsRuntimeConstant/test/IsRuntimeConstant.test.cpp
@@ -4,6 +4,8 @@
 #include "dimwits.hpp"
 #include "interpolation.hpp"
 
+#include "header-utilities/copy.hpp"
+
 using namespace njoy::interpolation;
 using namespace dimwits;
 
@@ -15,15 +17,15 @@ SCENARIO("An interpolation table can be constructed with a domain maximum"){
 
     Table< table::Type< LinearLinear,
 			table::search::Binary,
-			table::discontinuity::TakeLeft, 
+			table::discontinuity::TakeLeft,
 			std::vector< double >, std::vector< double > >,
 	   table::domain::max::IsRuntimeConstant >
       myTable( 4.0, njoy::utility::copy(xGrid), njoy::utility::copy(yGrid) );
 
     THEN("the table can be evaluated in the center interval"){
       REQUIRE( 4.0 == myTable.domainMax() );
-    }    
-    
+    }
+
     THEN("the table can be evaluated in the center interval"){
       REQUIRE( 6.0 == myTable( 2.5 ) );
     }

--- a/src/interpolation/table/domain/min/IsCompiletimeConstant/test/IsCompiletimeConstant.test.cpp
+++ b/src/interpolation/table/domain/min/IsCompiletimeConstant/test/IsCompiletimeConstant.test.cpp
@@ -4,6 +4,8 @@
 #include "dimwits.hpp"
 #include "interpolation.hpp"
 
+#include "header-utilities/copy.hpp"
+
 using namespace njoy::interpolation;
 using namespace dimwits;
 
@@ -18,7 +20,7 @@ SCENARIO("An interpolation table can be constructed"
 
     Table< table::Type< LinearLinear,
 			table::search::Binary,
-			table::discontinuity::TakeLeft, 
+			table::discontinuity::TakeLeft,
 			std::vector< double >,
 			std::vector< double > >,
 	   table::domain::min::IsCompiletimeConstant<Zero> >

--- a/src/interpolation/table/domain/min/IsRuntimeConstant/test/IsRuntimeConstant.test.cpp
+++ b/src/interpolation/table/domain/min/IsRuntimeConstant/test/IsRuntimeConstant.test.cpp
@@ -4,6 +4,8 @@
 #include "dimwits.hpp"
 #include "interpolation.hpp"
 
+#include "header-utilities/copy.hpp"
+
 using namespace njoy::interpolation;
 using namespace dimwits;
 
@@ -15,7 +17,7 @@ SCENARIO("An interpolation table can be constructed with a domain minimum"){
 
     Table< table::Type< LinearLinear,
 			table::search::Binary,
-			table::discontinuity::TakeLeft, 
+			table::discontinuity::TakeLeft,
 			std::vector< double >,
 			std::vector< double > >,
 	   table::domain::min::IsRuntimeConstant >

--- a/src/interpolation/table/left/interval/IsAsymptotic/test/IsAsymptotic.test.cpp
+++ b/src/interpolation/table/left/interval/IsAsymptotic/test/IsAsymptotic.test.cpp
@@ -3,6 +3,8 @@
 #include "catch.hpp"
 #include "interpolation.hpp"
 
+#include "range/v3/view/take_exactly.hpp"
+
 using namespace njoy::interpolation;
 
 SCENARIO("An asymptotic right interval can be applied to a table"){
@@ -13,7 +15,7 @@ SCENARIO("An asymptotic right interval can be applied to a table"){
     WHEN("constructing a Table with the search method"){
       Table< table::Type< LinearLinear,
 			  table::search::Binary,
-			  table::discontinuity::TakeLeft, 
+			  table::discontinuity::TakeLeft,
 			  std::vector< double >,
 			  std::vector< double > >,
 	     table::left::interval::IsAsymptotic >
@@ -26,11 +28,11 @@ SCENARIO("An asymptotic right interval can be applied to a table"){
     WHEN("constructing a Table without the search method"){
       const auto leftSize = 3;
       const auto rightSize = 6;
-      
+
       auto xLeft = xGrid
 	| ranges::view::drop_exactly( 0 )
 	| ranges::view::take_exactly( leftSize );
-      
+
       auto yLeft = yGrid
 	| ranges::view::drop_exactly( 0 )
 	| ranges::view::take_exactly( leftSize );
@@ -45,7 +47,7 @@ SCENARIO("An asymptotic right interval can be applied to a table"){
 
       using Component = Table< table::Type< LinearLinear,
 					    table::search::Binary,
-					    table::discontinuity::TakeLeft, 
+					    table::discontinuity::TakeLeft,
 					    decltype(xLeft), decltype(yLeft) > >;
 
       const std::vector<Component> core{ Component( njoy::utility::copy(xLeft),

--- a/src/interpolation/table/left/interval/IsAsymptotic/test/IsAsymptotic.test.cpp
+++ b/src/interpolation/table/left/interval/IsAsymptotic/test/IsAsymptotic.test.cpp
@@ -5,6 +5,8 @@
 
 #include "range/v3/view/take_exactly.hpp"
 
+#include "header-utilities/copy.hpp"
+
 using namespace njoy::interpolation;
 
 SCENARIO("An asymptotic right interval can be applied to a table"){

--- a/src/interpolation/table/left/interval/IsCompiletimeConstant/test/IsCompiletimeConstant.test.cpp
+++ b/src/interpolation/table/left/interval/IsCompiletimeConstant/test/IsCompiletimeConstant.test.cpp
@@ -4,6 +4,8 @@
 #include "dimwits.hpp"
 #include "interpolation.hpp"
 
+#include "header-utilities/copy.hpp"
+
 using namespace njoy::interpolation;
 using namespace dimwits;
 
@@ -18,7 +20,7 @@ SCENARIO("An interpolation table can be constructed"
 
     Table< table::Type< LinearLinear,
 			table::search::Binary,
-			table::discontinuity::TakeLeft, 
+			table::discontinuity::TakeLeft,
 			std::vector< double >,
 			std::vector< double > >,
 	   table::left::interval::IsCompiletimeConstant<Ten> >

--- a/src/interpolation/table/left/interval/IsRuntimeConstant/test/IsRuntimeConstant.test.cpp
+++ b/src/interpolation/table/left/interval/IsRuntimeConstant/test/IsRuntimeConstant.test.cpp
@@ -4,6 +4,8 @@
 #include "dimwits.hpp"
 #include "interpolation.hpp"
 
+#include "header-utilities/copy.hpp"
+
 using namespace njoy::interpolation;
 using namespace dimwits;
 
@@ -17,7 +19,7 @@ SCENARIO("An interpolation table can be constructed"
 
     Table< table::Type< LinearLinear,
 			table::search::Binary,
-			table::discontinuity::TakeLeft, 
+			table::discontinuity::TakeLeft,
 			std::vector< double >,
 			std::vector< double > >,
 	   table::left::interval::IsRuntimeConstant >

--- a/src/interpolation/table/left/interval/Throws/test/Throws.test.cpp
+++ b/src/interpolation/table/left/interval/Throws/test/Throws.test.cpp
@@ -4,6 +4,8 @@
 #include "dimwits.hpp"
 #include "interpolation.hpp"
 
+#include "header-utilities/copy.hpp"
+
 using namespace njoy::interpolation;
 using namespace dimwits;
 
@@ -17,7 +19,7 @@ SCENARIO("An interpolation table can be constructed"
 
     Table< table::Type< LinearLinear,
 			table::search::Binary,
-			table::discontinuity::TakeLeft, 
+			table::discontinuity::TakeLeft,
 			std::vector< double >,
 			std::vector< double > >,
 	   table::left::interval::Throws >

--- a/src/interpolation/table/make/test/make.test.cpp
+++ b/src/interpolation/table/make/test/make.test.cpp
@@ -3,6 +3,8 @@
 #include "catch.hpp"
 #include "interpolation.hpp"
 
+#include "header-utilities/copy.hpp"
+
 using namespace njoy::interpolation;
 
 struct Zero {
@@ -20,12 +22,12 @@ SCENARIO("table make factory function"){
 
     Table< table::Type< LinearLinear,
 			table::search::Binary,
-			table::discontinuity::TakeLeft, 
+			table::discontinuity::TakeLeft,
 			std::vector< double >,
 			std::vector< double > > >
       reference( njoy::utility::copy(xGrid), njoy::utility::copy(yGrid) );
 
-    
+
     THEN("table::make can infer the grid types"){
       auto trial =
 	table::make< LinearLinear,
@@ -39,7 +41,7 @@ SCENARIO("table make factory function"){
 
     THEN("table::make can apply defaults"){
       bool correct;
-      
+
       auto trial0 = table::make< LinearLinear >( njoy::utility::copy(xGrid),
 						 njoy::utility::copy(yGrid) );
 
@@ -53,7 +55,7 @@ SCENARIO("table make factory function"){
 
       correct = std::is_same< decltype(reference), decltype(trial1) >::value;
       REQUIRE( correct );
-      
+
       auto trial2 =
 	table::make< LinearLinear,
 		     table::discontinuity::TakeLeft >( njoy::utility::copy(xGrid),
@@ -66,7 +68,7 @@ SCENARIO("table make factory function"){
     THEN("table::make can apply decorators"){
       Table< table::Type< LinearLinear,
 			  table::search::Binary,
-			  table::discontinuity::TakeLeft, 
+			  table::discontinuity::TakeLeft,
 			  std::vector< double >,
 			  std::vector< double > >,
 	     table::domain::min::IsCompiletimeConstant<Zero>,
@@ -77,7 +79,7 @@ SCENARIO("table make factory function"){
 
       auto trial = table::make< LinearLinear,
 				table::search::Binary,
-				table::discontinuity::TakeLeft, 
+				table::discontinuity::TakeLeft,
 				table::domain::min::IsCompiletimeConstant<Zero>,
 				table::domain::max::IsCompiletimeConstant<Ten>,
 				table::left::interval::IsCompiletimeConstant<Zero>,

--- a/src/interpolation/table/right/interval/IsAsymptotic/test/IsAsymptotic.test.cpp
+++ b/src/interpolation/table/right/interval/IsAsymptotic/test/IsAsymptotic.test.cpp
@@ -3,6 +3,8 @@
 #include "catch.hpp"
 #include "interpolation.hpp"
 
+#include "range/v3/view/take_exactly.hpp"
+
 using namespace njoy::interpolation;
 
 SCENARIO("An asymptotic right interval can be applied to a table"){
@@ -13,7 +15,7 @@ SCENARIO("An asymptotic right interval can be applied to a table"){
     WHEN("constructing a Table with the search method"){
       Table< table::Type< LinearLinear,
 			  table::search::Binary,
-			  table::discontinuity::TakeLeft, 
+			  table::discontinuity::TakeLeft,
 			  std::vector< double >,
 			  std::vector< double > >,
 	     table::right::interval::IsAsymptotic >
@@ -26,11 +28,11 @@ SCENARIO("An asymptotic right interval can be applied to a table"){
     WHEN("constructing a Table without the search method"){
       const auto leftSize = 3;
       const auto rightSize = 6;
-      
+
       auto xLeft = xGrid
 	| ranges::view::drop_exactly( 0 )
 	| ranges::view::take_exactly( leftSize );
-      
+
       auto yLeft = yGrid
 	| ranges::view::drop_exactly( 0 )
 	| ranges::view::take_exactly( leftSize );
@@ -45,7 +47,7 @@ SCENARIO("An asymptotic right interval can be applied to a table"){
 
       using Component = Table< table::Type< LinearLinear,
 					    table::search::Binary,
-					    table::discontinuity::TakeLeft, 
+					    table::discontinuity::TakeLeft,
 					    decltype(xLeft), decltype(yLeft) > >;
 
       const std::vector<Component> core{ Component( njoy::utility::copy(xLeft),
@@ -56,7 +58,7 @@ SCENARIO("An asymptotic right interval can be applied to a table"){
       Table< table::Vector< Component >,
 	     table::right::interval::IsAsymptotic >
 	myTable( njoy::utility::copy( core ) );
-      
+
       REQUIRE( myTable(3.5) == 8.0 );
       REQUIRE( myTable(9.0) == 17.0 );
     }

--- a/src/interpolation/table/right/interval/IsAsymptotic/test/IsAsymptotic.test.cpp
+++ b/src/interpolation/table/right/interval/IsAsymptotic/test/IsAsymptotic.test.cpp
@@ -5,6 +5,8 @@
 
 #include "range/v3/view/take_exactly.hpp"
 
+#include "header-utilities/copy.hpp"
+
 using namespace njoy::interpolation;
 
 SCENARIO("An asymptotic right interval can be applied to a table"){

--- a/src/interpolation/table/right/interval/IsCompiletimeConstant/test/IsCompiletimeConstant.test.cpp
+++ b/src/interpolation/table/right/interval/IsCompiletimeConstant/test/IsCompiletimeConstant.test.cpp
@@ -4,6 +4,8 @@
 #include "dimwits.hpp"
 #include "interpolation.hpp"
 
+#include "header-utilities/copy.hpp"
+
 using namespace njoy::interpolation;
 using namespace dimwits;
 
@@ -18,7 +20,7 @@ SCENARIO("An interpolation table can be constructed"
 
     Table< table::Type< LinearLinear,
 			table::search::Binary,
-			table::discontinuity::TakeLeft, 
+			table::discontinuity::TakeLeft,
 			std::vector< double >,
 			std::vector< double > >,
 	   table::right::interval::IsCompiletimeConstant<Ten> >

--- a/src/interpolation/table/right/interval/IsRuntimeConstant/test/IsRuntimeConstant.test.cpp
+++ b/src/interpolation/table/right/interval/IsRuntimeConstant/test/IsRuntimeConstant.test.cpp
@@ -4,6 +4,8 @@
 #include "dimwits.hpp"
 #include "interpolation.hpp"
 
+#include "header-utilities/copy.hpp"
+
 using namespace njoy::interpolation;
 using namespace dimwits;
 
@@ -16,7 +18,7 @@ SCENARIO("An interpolation table can be constructed"
 
     Table< table::Type< LinearLinear,
 			table::search::Binary,
-			table::discontinuity::TakeLeft, 
+			table::discontinuity::TakeLeft,
 			std::vector< double >,
 			std::vector< double > >,
 	   table::right::interval::IsRuntimeConstant >

--- a/src/interpolation/table/right/interval/Throws/test/Throws.test.cpp
+++ b/src/interpolation/table/right/interval/Throws/test/Throws.test.cpp
@@ -4,6 +4,8 @@
 #include "dimwits.hpp"
 #include "interpolation.hpp"
 
+#include "header-utilities/copy.hpp"
+
 using namespace njoy::interpolation;
 using namespace dimwits;
 
@@ -17,7 +19,7 @@ SCENARIO("An interpolation table can be constructed"
 
     Table< table::Type< LinearLinear,
 			table::search::Binary,
-			table::discontinuity::TakeLeft, 
+			table::discontinuity::TakeLeft,
 			std::vector< double >,
 			std::vector< double > >,
 	table::right::interval::Throws >

--- a/src/interpolation/table/transform/test/transform.test.cpp
+++ b/src/interpolation/table/transform/test/transform.test.cpp
@@ -8,6 +8,8 @@
 #include "range/v3/numeric/accumulate.hpp"
 #include "range/v3/view/zip.hpp"
 
+#include "header-utilities/copy.hpp"
+
 using namespace njoy::interpolation;
 
 struct Zero {

--- a/src/interpolation/table/transform/test/transform.test.cpp
+++ b/src/interpolation/table/transform/test/transform.test.cpp
@@ -3,6 +3,11 @@
 #include "catch.hpp"
 #include "interpolation.hpp"
 
+#include <numeric>
+#include "range/v3/algorithm/for_each.hpp"
+#include "range/v3/numeric/accumulate.hpp"
+#include "range/v3/view/zip.hpp"
+
 using namespace njoy::interpolation;
 
 struct Zero {
@@ -17,7 +22,7 @@ template< typename Interp, typename Xrange, typename Yrange = Xrange >
 using Base =
   table::Type< Interp,
 	       table::search::Binary,
-	       table::discontinuity::TakeLeft, 
+	       table::discontinuity::TakeLeft,
 	       Xrange, Yrange >;
 
 struct Exponential {
@@ -30,7 +35,7 @@ struct Exponential {
 
 SCENARIO("An interpolation table can be constructed with transforms"){
   GIVEN("an x- and y-grid"){
-    
+
     std::vector< double > xGrid{1.0, 2.0, 3.0};
     std::vector< double > yGrid{3.0, 5.0, 7.0};
 
@@ -54,7 +59,7 @@ SCENARIO("An interpolation table can be constructed with transforms"){
 			    table::discontinuity::TakeLeft,
 			    decltype(expX), decltype(expY) > >
 	  reference( njoy::utility::copy(expX), njoy::utility::copy(expY) );
-	
+
 	ranges::for_each( ranges::view::zip( reference.x(), trial.x() ),
 			  []( auto&& pair ){
 			    REQUIRE( ( std::get<0>(pair) == std::get<1>(pair) ) );
@@ -136,7 +141,7 @@ SCENARIO("Transforms can change the input and output types"){
 			    table::discontinuity::TakeLeft,
 			    decltype(xMeters), decltype(ySeconds) > >
 	reference( njoy::utility::copy(xMeters), njoy::utility::copy(ySeconds) );
-	
+
 	ranges::for_each( ranges::view::zip( reference.x(), trial.x() ),
 			  []( auto&& pair ){
 			    REQUIRE( ( std::get<0>(pair) == std::get<1>(pair) ) );
@@ -150,4 +155,3 @@ SCENARIO("Transforms can change the input and output types"){
     }
   }
 }
-

--- a/src/interpolation/test/Example8.cpp
+++ b/src/interpolation/test/Example8.cpp
@@ -4,6 +4,8 @@
 #include "catch.hpp"
 #include "interpolation.hpp"
 
+#include "range/v3/view/take_exactly.hpp"
+
 using namespace njoy::interpolation;
 
 TEST_CASE("Example 8"){

--- a/src/interpolation/test/demo.cpp
+++ b/src/interpolation/test/demo.cpp
@@ -12,6 +12,8 @@
 #include "range/v3/view/take_exactly.hpp"
 #include "range/v3/view/zip.hpp"
 
+#include "header-utilities/copy.hpp"
+
 template< typename T >
 struct echo;
 

--- a/src/interpolation/test/demo.cpp
+++ b/src/interpolation/test/demo.cpp
@@ -9,6 +9,9 @@
 #include "boost/hana/ext/std/tuple.hpp"
 #include "boost/hana/ext/std/pair.hpp"
 
+#include "range/v3/view/take_exactly.hpp"
+#include "range/v3/view/zip.hpp"
+
 template< typename T >
 struct echo;
 
@@ -50,12 +53,12 @@ SCENARIO("Lets zip some vectors"){
     1.,  3.,  5.,  7.,  9., 11., 13., 15. };
 
   const int size = 8;
-  
+
   auto energyView = XSS
     | ranges::view::take_exactly( size );
 
   std::cout << energyView << std::endl;
-  
+
   auto totalView = XSS
     | ranges::view::drop_exactly( size )
     | ranges::view::take_exactly( size );
@@ -67,7 +70,7 @@ SCENARIO("Lets zip some vectors"){
     | ranges::view::take_exactly( size );
 
   std::cout << absorptionView << std::endl;
-  
+
   auto scatterView = XSS
     | ranges::view::drop_exactly( size * 3 )
     | ranges::view::take_exactly( size );
@@ -77,15 +80,15 @@ SCENARIO("Lets zip some vectors"){
   auto zippedVector =
     ranges::view::zip( energyView, scatterView, absorptionView, totalView )
     | ranges::to_vector;
-  
+
   std::cout << zippedVector << std::endl;
 
   auto energy = zippedVector
     | ranges::view::transform( []( const auto& arg ){
 	return std::get<0>(arg) * mega(electronVolts); } );
-  
+
   std::cout << energy << std::endl;
-  
+
   auto scattering = zippedVector
     | ranges::view::transform( []( const auto& arg ){
 	return std::get<1>(arg) * barn; } );
@@ -97,7 +100,7 @@ SCENARIO("Lets zip some vectors"){
 	return std::get<2>(arg) * barn; } );
 
   std::cout << absorption << std::endl;
-  
+
   auto total = zippedVector
     | ranges::view::transform( []( const auto& arg ){
 	return std::get<3>(arg) * barn; } );
@@ -117,7 +120,7 @@ SCENARIO("Lets zip some vectors"){
 				     utility::copy(scattering) );
 
   REQUIRE( 6.0 * barn == scatteringXS( 3.5 * mega(electronVolts) ) );
-  
+
   auto absorptionXS =
     interpolation::table::make
     < interpolation::LinearLinear >( utility::copy(energy),


### PR DESCRIPTION
This is an effort to reduce upstream compilation memory and time by reducing the amount of included code.

Any library including the interpolation library has had to take in the entire range/v3 library prior to this change. This change and a similar update to ENDFtk has lead to a reduction in compilation time using gcc of about 5% in resonanceReconstruction.